### PR TITLE
Refresh auth on mount, store for 90 days

### DIFF
--- a/src/_layout/AuthRefresh.tsx
+++ b/src/_layout/AuthRefresh.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import { useEffect } from 'react';
+import { updateAuthExpiration } from './updateAuthExpiration';
+
+export const AuthRefresh = () => {
+  useEffect(() => {
+    void updateAuthExpiration();
+  }, []);
+
+  return null;
+};

--- a/src/_layout/RootLayout.tsx
+++ b/src/_layout/RootLayout.tsx
@@ -2,10 +2,12 @@ import React from 'react';
 import { Header } from './Header';
 import './globals.css';
 import Head from 'next/head';
+import { AuthRefresh } from './AuthRefresh';
 
 export const RootLayout: React.FC<React.PropsWithChildren> = ({ children }) => {
   return (
     <html lang='en' dir='ltr' data-theme='cupcake'>
+      <AuthRefresh />
       <Head>
         <meta name='apple-mobile-web-app-title' content='Grocery' />
         <meta

--- a/src/_layout/updateAuthExpiration.ts
+++ b/src/_layout/updateAuthExpiration.ts
@@ -1,0 +1,11 @@
+'use server';
+
+import { getAuth, refreshAuth } from '@/auth';
+
+export const updateAuthExpiration = async () => {
+  const auth = await getAuth();
+
+  if (auth) {
+    await refreshAuth();
+  }
+};

--- a/src/libs/auth/auth.ts
+++ b/src/libs/auth/auth.ts
@@ -14,6 +14,7 @@ const getSession = async () => {
     cookieName: 'auth',
     cookieOptions: {
       secure: isProduction(),
+      maxAge: 90 * 24 * 60 * 60, // 90 days
     },
   });
 };
@@ -56,4 +57,10 @@ export const deleteAuth = async () => {
   const session = await getSession();
 
   session.destroy();
+};
+
+export const refreshAuth = async (): Promise<void> => {
+  const session = await getSession();
+
+  await session.save();
 };

--- a/src/libs/auth/index.ts
+++ b/src/libs/auth/index.ts
@@ -1,1 +1,1 @@
-export { getAuth, getUuid, createAuth, deleteAuth } from './auth';
+export { getAuth, getUuid, createAuth, deleteAuth, refreshAuth } from './auth';


### PR DESCRIPTION
## Description

* adding 90 days expiration for cookies (instead of default session-based)
* refreshing the cookies on client mount (making it infinite in case of regular usage)